### PR TITLE
Migrate to react 18 syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import './index.css';
 import { BrowserRouter } from 'react-router-dom';
@@ -7,7 +7,8 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import store from './redux/configureStore';
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('root'));
+root.render(
   <React.StrictMode>
     <Provider store={store}>
       <BrowserRouter>
@@ -15,7 +16,6 @@ ReactDOM.render(
       </BrowserRouter>
     </Provider>
   </React.StrictMode>,
-  document.getElementById('root'),
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -41,7 +41,7 @@ export const leaveMission = (id) => ({
 export default function reducer(state = [], action) {
   switch (action.type) {
     case FETCH_MISSIONS_SUCCESS:
-      return [...state, ...action.payload.missions];
+      return action.payload.missions;
 
     case JOIN_MISSION:
       return state.map((s) => (s.id === action.payload.id ? { ...s, joined: true } : s));

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -39,7 +39,7 @@ export const fetchRocketsFromServer = () => async (dispatch) => {
 const rocketReducer = (state = InitialState, action) => {
   switch (action.type) {
     case FETCH_ROCKETS:
-      return [...state, ...action.payload.rockets];
+      return action.payload.rockets;
 
     case BOOK_ROCKET:
       return state.map((rocket) => (


### PR DESCRIPTION
In this PR, I have changed `index.js` file to mound the root element with React 18 syntax.

As side effect, rockets and missions get rendered twice. As a temporary solution, I edited actions for both rockets and missions to make sure we set the state to the received data from API rather appending them.